### PR TITLE
Export default registry classes as types.

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -27,6 +27,7 @@ _Welo.Replicator = MultiReplicator
 
 export { _Welo as Welo }
 
+export { StaticAccess, Entry, Identity, Keyvalue }
 export type { Manifest, Address } from '~manifest/index.js'
 export type { Playable } from '~utils/playable.js'
 export type { Database } from './database.js'


### PR DESCRIPTION
This PR just exports the classes that are added to the registry as types so users can use these as types.

```typescript
import type { Keyvalue } from 'welo'

const store = db.store as Keyvalue
```