### PR TITLE
fix: Fix the multi replicator start/stop.

### DIFF
--- a/src/replicator/multi/index.ts
+++ b/src/replicator/multi/index.ts
@@ -20,10 +20,10 @@ export class MultiReplicator extends Playable implements Replicator {
 
   constructor (config: Config) {
     const starting = async (): Promise<void> => {
-      await start(this.replicators)
+      await start(...this.replicators)
     }
     const stopping = async (): Promise<void> => {
-      await stop(this.replicators)
+      await stop(...this.replicators)
     }
 
     super({ starting, stopping })


### PR DESCRIPTION
This PR fixes the starting and stopping of the multi replicator's replicators.

The issue occurred because [an array was passed](https://github.com/hldb/welo/blob/master/src/replicator/multi/index.ts#L23) to the `start`/`stop` methods instead of [individual arguments](https://github.com/libp2p/js-libp2p-interfaces/blob/master/packages/interfaces/src/startable.ts#L55).