### PR TITLE
fix: bootstrap replicator errors

### DIFF
--- a/src/replicator/bootstrap/index.ts
+++ b/src/replicator/bootstrap/index.ts
@@ -116,14 +116,14 @@ export class BootstrapReplicator extends Playable {
       promises.push(Promise.resolve().then(async () => {
         if (!await this.libp2p.peerStore.has(peer.id)) {
           await this.libp2p.peerStore.save(peer.id, peer)
-
-          // We need to dial so that libp2p can update multiaddrs.
-          await this.libp2p.dial(peer.id)
         }
+
+        // We need to dial so that libp2p can update multiaddrs.
+        await this.libp2p.dial(peer.id)
 
         const stream = await this.libp2p.dialProtocol(peer.id, this.protocol)
         await this.exchange(stream, peer.id)
-      }))
+      }).catch(() => {}))
     }
 
     // Don't really care if individual head syncs fail.

--- a/src/replicator/bootstrap/index.ts
+++ b/src/replicator/bootstrap/index.ts
@@ -102,7 +102,11 @@ export class BootstrapReplicator extends Playable {
   }
 
   private async handle ({ stream, connection }: { stream: Stream, connection: Connection }): Promise<void> {
-    await this.exchange(stream, connection.remotePeer, this.options.reverseSync)
+    try {
+      await this.exchange(stream, connection.remotePeer, this.options.reverseSync)
+    } catch (error) {
+      // Ignore
+    }
   }
 
   private async bootstrap (): Promise<void> {


### PR DESCRIPTION
I have run into a couple errors causing crashes in the bootstrap replicator, one caused by a failed heads exchange which can be caught and safely ignored and the other is caused by not handling promises until after the async loop which if they reject beforehand they are unhandled.