### PR TITLE
fix: prevent heads exchange hanging

### DIFF
--- a/src/utils/heads-exchange.ts
+++ b/src/utils/heads-exchange.ts
@@ -249,10 +249,15 @@ export class HeadsExchange {
 
     const localHash = await hashHeads(this.heads)
     const remoteHash = CID.decode(message.hash)
+    const match = localHash.equals(remoteHash)
 
-    return {
-      match: localHash.equals(remoteHash)
+    if (this.verifyPromise == null) {
+      this.verifyPromise = new DeferredPromise(resolve => { resolve(match) })
+    } else {
+      this.verifyPromise?.resolve(match)
     }
+
+    return { match }
   }
 
   private handleVerifyResponse (message: Message): void {


### PR DESCRIPTION
This PR fixes the potential hang in syncing the heads over the bootstrap replicator if the remote validates before the local requests the validation.