### PR TITLE
feat: allow any file to be imported

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,10 @@
     ".": {
       "types": "./dist/src/index.d.ts",
       "import": "./dist/src/index.js"
+    },
+    "./*": {
+      "types": "./dist/src/*.d.ts",
+      "import": "./dist/src/*.js"
     }
   },
   "eslintConfig": {


### PR DESCRIPTION
This PR allows all files to be imported.

There are many classes and methods that would  be useful to be used outside the module such as:

- `Manifest.asManifest`
- `decodeCbor<ManifestData>`
- `HeadsExchange`, `getHeads`, `addHeads`

This is a catch-all solution which may not be ideal so let me know if there is reason to restrict this.