### PR TITLE
fix: prevent the heads promise from throwing

### DIFF
--- a/src/utils/heads-exchange.ts
+++ b/src/utils/heads-exchange.ts
@@ -163,8 +163,6 @@ export class HeadsExchange {
       return this.headsPromise
     }
 
-    this.headsPromise = new DeferredPromise()
-
     const { filter, hashes } = createFilter(this.heads, {
       seed: this.localSeed,
       collisionRate: this.collisionRate
@@ -180,6 +178,8 @@ export class HeadsExchange {
     }
 
     this.writer.push({ filter: message })
+
+    this.headsPromise = new DeferredPromise()
 
     return this.headsPromise
   }


### PR DESCRIPTION
This PR simply moves the deferred promise to the end of the method so that if any of the sync code throws an error (#113) it doesn't prevent the awaiting of the deferred promise.