### PR TITLE
feat: Abortable Requests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -65,6 +65,7 @@
         "eslint-plugin-promise": "^6.1.1",
         "eslint-plugin-tsdoc": "^0.2.17",
         "interface-datastore": "^8.2.10",
+        "interface-store": "^5.1.8",
         "ipns": "^8.0.0",
         "level": "^8.0.0",
         "libp2p": "^1.1.1",
@@ -15342,9 +15343,9 @@
       }
     },
     "node_modules/interface-store": {
-      "version": "5.1.7",
-      "resolved": "https://registry.npmjs.org/interface-store/-/interface-store-5.1.7.tgz",
-      "integrity": "sha512-DVMTgZ43NAdDtXL3QsEq8N0vuUYVBxiGbxN0uI0lrNasuX/CGSrU7bjOO2DaGTMNut4Pt3ae+VQYFvNtH4Oyeg=="
+      "version": "5.1.8",
+      "resolved": "https://registry.npmjs.org/interface-store/-/interface-store-5.1.8.tgz",
+      "integrity": "sha512-7na81Uxkl0vqk0CBPO5PvyTkdaJBaezwUJGsMOz7riPOq0rJt+7W31iaopaMICWea/iykUsvNlPx/Tc+MxC3/w=="
     },
     "node_modules/internal-slot": {
       "version": "1.0.6",

--- a/package.json
+++ b/package.json
@@ -101,6 +101,7 @@
     "eslint-plugin-promise": "^6.1.1",
     "eslint-plugin-tsdoc": "^0.2.17",
     "interface-datastore": "^8.2.10",
+    "interface-store": "^5.1.8",
     "ipns": "^8.0.0",
     "level": "^8.0.0",
     "libp2p": "^1.1.1",

--- a/src/entry/basal/index.ts
+++ b/src/entry/basal/index.ts
@@ -8,6 +8,7 @@ import type {
   AsEntry
 } from '../interface.js'
 import type { IdentityInstance } from '@/identity/interface.js'
+import type { AbortOptions } from 'interface-store'
 import type { CID } from 'multiformats/cid'
 import type { BlockView } from 'multiformats/interface'
 import { encodeCbor, decodeCbor } from '@/utils/block.js'
@@ -91,11 +92,11 @@ const asEntry = async (entry: AsEntry<unknown>): Promise<Entry | null> => {
   return new Entry({ block: asSigned, data, identity })
 }
 
-const fetch = async ({ blockstore, identity, cid }: Fetch): Promise<Entry> => {
-  const bytes = await blockstore.get(cid)
+const fetch = async ({ blockstore, identity, cid }: Fetch, options?: AbortOptions): Promise<Entry> => {
+  const bytes = await blockstore.get(cid, options)
   const block = await decodeCbor<SignedEntry>(bytes)
   const { auth } = block.value
-  const identityInstance = await identity.fetch({ blockstore, auth })
+  const identityInstance = await identity.fetch({ blockstore, auth }, options)
 
   const entry = await asEntry({ block, identity: identityInstance })
 

--- a/src/entry/interface.ts
+++ b/src/entry/interface.ts
@@ -1,6 +1,7 @@
 import type { IdentityInstance, IdentityComponent } from '@/identity/interface.js'
 import type { ComponentProtocol } from '@/interface.js'
 import type { Blockstore } from 'interface-blockstore'
+import type { AbortOptions } from 'interface-store'
 import type { CID } from 'multiformats/cid'
 import type { BlockView } from 'multiformats/interface'
 import { HLDB_PREFIX } from '@/utils/constants.js'
@@ -26,14 +27,13 @@ export interface Fetch {
   blockstore: Blockstore
   identity: IdentityComponent<any>
   cid: CID
-  timeout?: number
 }
 
 export type AsEntry<Value> = Pick<EntryInstance<Value>, 'block' | 'identity'>
 
 export interface EntryComponent<T extends EntryInstance<unknown> = EntryInstance<unknown>, P extends string = string> extends ComponentProtocol<P> {
   create(create: Create): Promise<T>
-  fetch(fetch: Fetch): Promise<T>
+  fetch(fetch: Fetch, options?: AbortOptions): Promise<T>
   asEntry(entry: AsEntry<unknown>): Promise<T | null>
   verify(entry: AsEntry<unknown>): Promise<boolean>
 }

--- a/src/identity/basal/index.ts
+++ b/src/identity/basal/index.ts
@@ -14,6 +14,7 @@ import type {
   Import
 } from '../interface.js'
 import type { PrivateKey, PublicKey } from '@libp2p/interface/keys'
+import type { AbortOptions } from 'interface-store'
 import type { CID } from 'multiformats/cid'
 import type { BlockView } from 'multiformats/interface'
 import { decodeCbor, encodeCbor } from '@/utils/block.js'
@@ -132,8 +133,8 @@ const get = async ({ name, identities, keychain }: Get): Promise<Identity> => {
   }
 }
 
-const fetch = async ({ blockstore, auth: cid }: Fetch): Promise<Identity> => {
-  const bytes = await blockstore.get(cid)
+const fetch = async ({ blockstore, auth: cid }: Fetch, options?: AbortOptions): Promise<Identity> => {
+  const bytes = await blockstore.get(cid, options)
   const block = await decodeCbor<IdentityValue>(bytes)
 
   const identity = asIdentity({ block })

--- a/src/identity/interface.ts
+++ b/src/identity/interface.ts
@@ -2,6 +2,7 @@ import type { ComponentProtocol } from '@/interface.js'
 import type { Keychain } from '@libp2p/keychain'
 import type { Blockstore } from 'interface-blockstore'
 import type { Datastore } from 'interface-datastore'
+import type { AbortOptions } from 'interface-store'
 import type { CID } from 'multiformats/cid'
 import type { BlockView } from 'multiformats/interface'
 import { HLDB_PREFIX } from '@/utils/constants.js'
@@ -44,7 +45,7 @@ export interface IdentityInstance<Value> {
 export interface IdentityComponent<T extends IdentityInstance<unknown> = IdentityInstance<unknown>, P extends string = string> extends ComponentProtocol<P> {
   gen(gen: Gen): Promise<T>
   get(get: Get): Promise<T>
-  fetch(fetch: Fetch): Promise<T>
+  fetch(fetch: Fetch, options?: AbortOptions): Promise<T>
   asIdentity(asIdentity: AsIdentity<unknown>): T | null
   import(imp: Import): Promise<T>
   export(exp: Export): Promise<Uint8Array>

--- a/src/manifest/index.ts
+++ b/src/manifest/index.ts
@@ -6,6 +6,7 @@ import type {
   ManifestData,
   Protocol
 } from './interface.js'
+import type { AbortOptions } from 'interface-store'
 import type { BlockView } from 'multiformats/interface'
 import { decodeCbor, encodeCbor } from '@/utils/block.js'
 // import type { FetchOptions } from '@/utils/types.js'
@@ -77,9 +78,10 @@ export class Manifest {
    * @returns
    */
   static async fetch (
-    { blockstore, address }: Fetch
+    { blockstore, address }: Fetch,
+    options?: AbortOptions
   ): Promise<Manifest> {
-    const bytes = await blockstore.get(address.cid)
+    const bytes = await blockstore.get(address.cid, options)
     const block = await decodeCbor<ManifestData>(bytes)
     const manifest = this.asManifest({ block })
 

--- a/src/welo.ts
+++ b/src/welo.ts
@@ -26,6 +26,7 @@ import type { ReplicatorModule } from '@/replicator/interface.js'
 import type { Keychain } from '@libp2p/keychain'
 import type { Blockstore } from 'interface-blockstore'
 import type { Datastore } from 'interface-datastore'
+import type { AbortOptions } from 'interface-store'
 import { Manifest, Address } from '@/manifest/index.js'
 import { DATABASE_NAMESPACE, IDENTITY_NAMESPACE } from '@/utils/constants.js'
 import { cidstring } from '@/utils/index.js'
@@ -108,17 +109,17 @@ export class Welo extends Playable {
    *
    * Options are shallow merged with {@link defaultManifest}.
    *
-   * @param options - Override defaults used to create the manifest.
+   * @param settings - Override defaults used to create the manifest.
    * @returns
    */
-  async determine (options: Determine): Promise<Manifest> {
+  async determine (settings: Determine, options?: AbortOptions): Promise<Manifest> {
     const manifestObj: ManifestData = {
-      ...this.getDefaultManifest(options.name),
-      ...options
+      ...this.getDefaultManifest(settings.name),
+      ...settings
     }
 
     const manifest = await Manifest.create(manifestObj)
-    await this.blockstore.put(manifest.block.cid, manifest.block.bytes)
+    await this.blockstore.put(manifest.block.cid, manifest.block.bytes, options)
 
     try {
       this.getComponents(manifest)
@@ -138,8 +139,8 @@ export class Welo extends Playable {
    * @param address - the Address of the Manifest to fetch
    * @returns
    */
-  async fetch (address: Address): Promise<Manifest> {
-    return Manifest.fetch({ blockstore: this.blockstore, address })
+  async fetch (address: Address, options?: AbortOptions): Promise<Manifest> {
+    return Manifest.fetch({ blockstore: this.blockstore, address }, options)
   }
 
   /**


### PR DESCRIPTION
This PR adds an abort options parameter to requests so they can be aborted by the caller.

The main target here is the `welo.fetch`/`Manifest.fetch` but i have added it to identity and entry, replacing the timeout parameter.

There are probably a few other requests that might need to be abortable inside database/replica/etc, I am hoping these will be added in next gen or are easier to figure out after.